### PR TITLE
Feature/kill instead of remove

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.shadow)
     alias(libs.plugins.plugin.yml)
 }
-version = "4.3.5"
+version = "4.3.6"
 description = "Limit entities in chunks."
 
 

--- a/src/main/java/com/cyprias/chunkspawnerlimiter/configs/CslConfig.java
+++ b/src/main/java/com/cyprias/chunkspawnerlimiter/configs/CslConfig.java
@@ -58,7 +58,7 @@ public class CslConfig extends ConfigFile<ChunkSpawnerLimiter>{
 		this.preserveRaidEntities = config.getBoolean(propertiesPath + "preserve-raid-entities", true);
 		this.ignoreMetadata = config.getStringList(propertiesPath + "ignore-metadata");
 		this.killInsteadOfRemove = config.getBoolean(propertiesPath + "kill-instead-of-remove", false);
-		
+
 		String messagesPath = "messages.";
 		this.removedEntities = config.getString(messagesPath + "removedEntities");
 		this.reloadedConfig = config.getString(messagesPath + "reloadedConfig", "&cReloaded csl config.");
@@ -142,6 +142,10 @@ public class CslConfig extends ConfigFile<ChunkSpawnerLimiter>{
 	
 	public List<String> getIgnoreMetadata() {
 		return ignoreMetadata;
+	}
+
+	public boolean isKillInsteadOfRemove() {
+		return killInsteadOfRemove;
 	}
 
 	public String getRemovedEntities() {

--- a/src/main/java/com/cyprias/chunkspawnerlimiter/configs/CslConfig.java
+++ b/src/main/java/com/cyprias/chunkspawnerlimiter/configs/CslConfig.java
@@ -22,6 +22,8 @@ public class CslConfig extends ConfigFile<ChunkSpawnerLimiter>{
 	private boolean preserveNamedEntities;
 	private boolean preserveRaidEntities;
 	private List<String> ignoreMetadata;
+	private boolean killInsteadOfRemove;
+
 	/* Messages */
 	private String removedEntities;
 	private String reloadedConfig;
@@ -31,6 +33,7 @@ public class CslConfig extends ConfigFile<ChunkSpawnerLimiter>{
 	private String maxAmountBlocksSubtitle;
 
 	private List<String> excludedWorlds;
+
 
 
 	public CslConfig(final @NotNull ChunkSpawnerLimiter plugin) {
@@ -54,6 +57,8 @@ public class CslConfig extends ConfigFile<ChunkSpawnerLimiter>{
 		this.preserveNamedEntities = config.getBoolean(propertiesPath + "preserve-named-entities", true);
 		this.preserveRaidEntities = config.getBoolean(propertiesPath + "preserve-raid-entities", true);
 		this.ignoreMetadata = config.getStringList(propertiesPath + "ignore-metadata");
+		this.killInsteadOfRemove = config.getBoolean(propertiesPath + "kill-instead-of-remove", false);
+		
 		String messagesPath = "messages.";
 		this.removedEntities = config.getString(messagesPath + "removedEntities");
 		this.reloadedConfig = config.getString(messagesPath + "reloadedConfig", "&cReloaded csl config.");

--- a/src/main/java/com/cyprias/chunkspawnerlimiter/listeners/WorldListener.java
+++ b/src/main/java/com/cyprias/chunkspawnerlimiter/listeners/WorldListener.java
@@ -11,10 +11,7 @@ import com.cyprias.chunkspawnerlimiter.tasks.InspectTask;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Raid;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Raider;
+import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.world.ChunkLoadEvent;
@@ -127,8 +124,18 @@ public class WorldListener implements Listener {
             final Entity entity = entry.getValue().get(i);
             if (hasMetaData(entity) || hasCustomName(entity) || (entity instanceof Player) || isPartOfRaid(entity))
                 continue;
-            entity.remove();
+
+            if (config.isKillInsteadOfRemove() && isKillable(entity)) {
+                ((Damageable)entity).setHealth(0.0D);
+            } else {
+                entity.remove();
+            }
+
         }
+    }
+
+    public static boolean isKillable(final Entity entity) {
+        return entity instanceof Damageable;
     }
 
     private static @NotNull HashMap<String, ArrayList<Entity>> addEntitiesByConfig(Entity @NotNull [] entities) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -37,6 +37,8 @@ properties:
   ignore-metadata:
     - shopkeeper
 
+  kill-instead-of-remove: false
+
 # Spawn reasons to cull on.
 spawn-reasons:
   BREEDING: true


### PR DESCRIPTION
This PR implements a new feature that allows you to kill an entity, instead of removing it if it reaches the chunk limit.

This only applies to entities that implement the damagable interface.