### PR TITLE
Include / Exclude Worlds

### DIFF
--- a/src/main/java/com/cyprias/chunkspawnerlimiter/commands/CslCommand.java
+++ b/src/main/java/com/cyprias/chunkspawnerlimiter/commands/CslCommand.java
@@ -52,7 +52,8 @@ public class CslCommand extends BaseCommand {
         ChatUtil.message(sender,"Notify Players: %s",plugin.getCslConfig().isNotifyPlayers());
         ChatUtil.message(sender,"Preserve Named Entities: %s", plugin.getCslConfig().isPreserveNamedEntities());
         ChatUtil.message(sender,"Ignore Metadata: %s", plugin.getCslConfig().getIgnoreMetadata().toString());
-        ChatUtil.message(sender,"Excluded Worlds: %s", plugin.getCslConfig().getExcludedWorlds());
+        ChatUtil.message(sender, "Worlds Mode: %s",plugin.getCslConfig().getWorldsMode().name());
+        ChatUtil.message(sender,"Worlds: %s", plugin.getCslConfig().getWorldNames());
         ChatUtil.message(sender,"&2&l-- Messages --");
         ChatUtil.message(sender,"Reloaded Config: %s", plugin.getCslConfig().getReloadedConfig());
         ChatUtil.message(sender,"Removed Entities: %s", plugin.getCslConfig().getRemovedEntities());

--- a/src/main/java/com/cyprias/chunkspawnerlimiter/configs/CslConfig.java
+++ b/src/main/java/com/cyprias/chunkspawnerlimiter/configs/CslConfig.java
@@ -4,6 +4,7 @@ import com.cyprias.chunkspawnerlimiter.ChunkSpawnerLimiter;
 import org.bukkit.configuration.ConfigurationSection;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collections;
 import java.util.List;
 
 public class CslConfig extends ConfigFile<ChunkSpawnerLimiter>{
@@ -92,6 +93,33 @@ public class CslConfig extends ConfigFile<ChunkSpawnerLimiter>{
 		return config.getConfigurationSection("entities");
 	}
 
+	public boolean isWorldAllowed(final String worldName) {
+		final List<String> worldNames = getWorldNames();
+		if (getWorldsMode() == WorldsMode.EXCLUDED) {
+			return !worldNames.contains(worldName);
+		}
+		// INCLUDED
+		return worldNames.contains(worldName);
+	}
+
+	public boolean isWorldNotAllowed(final String worldName) {
+		return !isWorldAllowed(worldName);
+	}
+
+	public List<String> getWorldNames() {
+		return config.getStringList("worlds.worlds");
+	}
+
+	public WorldsMode getWorldsMode() {
+		final String mode = config.getString("worlds.mode", "excluded");
+		if (mode == null) {
+			return WorldsMode.EXCLUDED;
+		}
+
+		return WorldsMode.valueOf(mode.toUpperCase());
+	}
+
+	@Deprecated
 	public List<String> getExcludedWorlds() {
 		return excludedWorlds;
 	}
@@ -166,5 +194,10 @@ public class CslConfig extends ConfigFile<ChunkSpawnerLimiter>{
 
 	public String getMaxAmountBlocksSubtitle() {
 		return maxAmountBlocksSubtitle;
+	}
+
+	public enum WorldsMode {
+		INCLUDED,
+		EXCLUDED
 	}
 }

--- a/src/main/java/com/cyprias/chunkspawnerlimiter/listeners/PlaceBlockListener.java
+++ b/src/main/java/com/cyprias/chunkspawnerlimiter/listeners/PlaceBlockListener.java
@@ -27,7 +27,7 @@ public class PlaceBlockListener implements Listener {
             return;
         }
 
-        if (plugin.getCslConfig().getExcludedWorlds().contains(event.getBlock().getChunk().getWorld().getName())) {
+        if (plugin.getCslConfig().isWorldNotAllowed(event.getBlock().getChunk().getWorld().getName())) {
             return;
         }
 

--- a/src/main/java/com/cyprias/chunkspawnerlimiter/listeners/WorldListener.java
+++ b/src/main/java/com/cyprias/chunkspawnerlimiter/listeners/WorldListener.java
@@ -35,6 +35,10 @@ public class WorldListener implements Listener {
 
     @EventHandler
     public void onChunkLoadEvent(@NotNull ChunkLoadEvent event) {
+        if (config.isWorldNotAllowed(event.getWorld().getName())) {
+            return;
+        }
+        
         ChatUtil.debug(Debug.CHUNK_LOAD_EVENT,event.getChunk().getX(),event.getChunk().getZ());
         if (plugin.getCslConfig().isActiveInspections()) {
             InspectTask inspectTask = new InspectTask(event.getChunk());
@@ -50,6 +54,10 @@ public class WorldListener implements Listener {
 
     @EventHandler
     public void onChunkUnloadEvent(@NotNull ChunkUnloadEvent event) {
+        if (config.isWorldNotAllowed(event.getWorld().getName())) {
+            return;
+        }
+
         ChatUtil.debug(Debug.CHUNK_UNLOAD_EVENT,event.getChunk().getX(),event.getChunk().getZ());
 
         if (chunkTasks.containsKey(event.getChunk())) {

--- a/src/main/java/com/cyprias/chunkspawnerlimiter/listeners/WorldListener.java
+++ b/src/main/java/com/cyprias/chunkspawnerlimiter/listeners/WorldListener.java
@@ -67,7 +67,7 @@ public class WorldListener implements Listener {
      * @param chunk Chunk
      */
     public static void checkChunk(@NotNull Chunk chunk) {
-        if (config.getExcludedWorlds().contains(chunk.getWorld().getName())) {
+        if (config.isWorldNotAllowed(chunk.getWorld().getName())) {
             return;
         }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -98,8 +98,11 @@ entities:
 #  HORSE: 10
 #  WITCH: 10
 
-# Exclude these worlds from limits.  
-excluded-worlds: []
+# Exclude these worlds from limits.
+worlds:
+  # Can be "exclude" or "include"
+  mode: exclude
+  worlds: []
 
 messages:
   removedEntities: "&7Removed %s %s in your chunk."

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -100,8 +100,8 @@ entities:
 
 # Exclude these worlds from limits.
 worlds:
-  # Can be "exclude" or "include"
-  mode: exclude
+  # Can be "excluded" or "included"
+  mode: excluded
   worlds: []
 
 messages:


### PR DESCRIPTION
The excluded worlds config entry has been removed. Instead we now have a "worlds" section.

```
worlds:
  mode: "excluded"
  worlds: []
```

This allows worlds to either be excluded from the checks, or to be limited to just the set worlds.