### PR TITLE
Better Task cancelling

### DIFF
--- a/src/main/java/com/cyprias/chunkspawnerlimiter/inspection/entities/EntityInspectTask.java
+++ b/src/main/java/com/cyprias/chunkspawnerlimiter/inspection/entities/EntityInspectTask.java
@@ -41,15 +41,11 @@ public class EntityInspectTask extends BukkitRunnable {
     public void run() {
         final Chunk chunk = this.refChunk.get();
         if (chunk == null || !chunk.isLoaded()) {
-            Bukkit.getLogger().fine("Chunk is null or unloaded! Ignoring");
+            ChunkSpawnerLimiter.cancelTask(id);
             return;
         }
 
         ChatUtil.debug(Debug.ACTIVE_CHECK, chunk.getX(), chunk.getZ());
-        if (!chunk.isLoaded()) {
-            ChunkSpawnerLimiter.cancelTask(id);
-            return;
-        }
 
         entityChunkInspector.checkChunk(chunk);
     }


### PR DESCRIPTION
The previous if statement didn't make much sense and cancelTask could never execute.

I am looking for what to do with the **million** (!) tasks created _(version 4.3.12, so old Task name)_:
![image](https://github.com/user-attachments/assets/6084e289-ed37-4048-8edc-4ec8d2813c31)
and perhaps it will help at least slightly in my case and this one:
![image](https://github.com/user-attachments/assets/46583ec7-9b82-45fe-b29a-47959f4986a1)

But I think, it would still be best to use the event from the: #81 and totally remove this Task